### PR TITLE
Making the mapPartitions function pipeline'able

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,15 +125,15 @@ that open a pull request and we will review it.
 | persist                           | :x:                |                                                                   |
 | pipe                              | :x:                |                                                                   |
 | randomSplit                       | :x:                |                                                                   |
-| reduce                            | :x:                |                                                                   |
+| reduce                            | :white_check_mark: |                                                                   |
 | reduceByKey                       | :x:                |                                                                   |
 | repartition                       | :x:                |                                                                   |
 | repartitionAndSortWithinPartition | :x:                |                                                                   |
 | rightOuterJoin                    | :x:                |                                                                   |
 | sample                            | :x:                |                                                                   |
 | sampleByKey                       | :x:                |                                                                   |
-| sampleStdev                       | :x:                |                                                                   |
-| sampleVariance                    | :x:                |                                                                   |
+| sampleStdev                       | :white_check_mark: |                                                                   |
+| sampleVariance                    | :white_check_mark: |                                                                   |
 | saveAsHadoopDataset               | :x:                |                                                                   |
 | saveAsHadoopFile                  | :x:                |                                                                   |
 | saveAsNewAPIHadoopDataset         | :x:                |                                                                   |
@@ -143,8 +143,8 @@ that open a pull request and we will review it.
 | setName                           | :x:                |                                                                   |
 | sortBy                            | :x:                |                                                                   |
 | sortByKey                         | :x:                |                                                                   |
-| stats                             | :x:                |                                                                   |
-| stdev                             | :x:                |                                                                   |
+| stats                             | :white_check_mark: |                                                                   |
+| stdev                             | :white_check_mark: |                                                                   |
 | subtract                          | :x:                |                                                                   |
 | substractByKey                    | :x:                |                                                                   |
 | sum                               | :white_check_mark: | First version.                                                    |
@@ -161,7 +161,7 @@ that open a pull request and we will review it.
 | union                             | :x:                |                                                                   |
 | unpersist                         | :x:                |                                                                   |
 | values                            | :white_check_mark: |                                                                   |
-| variance                          | :x:                |                                                                   |
+| variance                          | :white_check_mark: |                                                                   |
 | withResources                     | :x:                |                                                                   |
 | zip                               | :x:                |                                                                   |
 | zipWithIndex                      | :x:                |                                                                   |

--- a/tests/test_rdd_adapter.py
+++ b/tests/test_rdd_adapter.py
@@ -174,3 +174,57 @@ def test_rdd_key_by(spark_session: "SparkSession"):
         (16, 8),
         (18, 9),
     ]
+
+
+def test_rdd_stats(spark_session: "SparkSession"):
+    monkey_patch_spark()
+    rdd = spark_session.sparkContext.parallelize(range(10))
+    stats = rdd.stats()
+    assert stats.count() == 10
+    assert stats.mean() == 4.5
+    assert stats.sum() == 45
+    assert stats.min() == 0
+    assert stats.max() == 9
+    assert stats.stdev() == 2.8722813232690143
+    assert stats.variance() == 8.25
+    assert stats.sampleStdev() == 3.0276503540974917
+    assert stats.sampleVariance() == 9.166666666666666
+
+
+def test_rdd_stddev(spark_session: "SparkSession"):
+    monkey_patch_spark()
+    rdd = spark_session.sparkContext.parallelize(range(10))
+    assert rdd.stdev() == 2.8722813232690143
+
+
+def test_rdd_sample_stddev(spark_session: "SparkSession"):
+    monkey_patch_spark()
+    rdd = spark_session.sparkContext.parallelize(range(10))
+    assert rdd.sampleStdev() == 3.0276503540974917
+
+
+def test_rdd_sample_variance(spark_session: "SparkSession"):
+    monkey_patch_spark()
+    rdd = spark_session.sparkContext.parallelize(range(10))
+    assert rdd.sampleVariance() == 9.166666666666666
+
+
+def test_rdd_variance(spark_session: "SparkSession"):
+    monkey_patch_spark()
+    rdd = spark_session.sparkContext.parallelize(range(10))
+    assert rdd.variance() == 8.25
+
+
+def test_rdd_aggregate(spark_session: "SparkSession"):
+    monkey_patch_spark()
+    rdd = spark_session.sparkContext.parallelize(range(10))
+    assert rdd.aggregate(0, lambda x, y: x + y, lambda x, y: x + y) == 45
+
+    seqOp = lambda x, y: (x[0] + y, x[1] + 1)
+    combOp = lambda x, y: (x[0] + y[0], x[1] + y[1])
+    res = spark_session.sparkContext.parallelize([1, 2, 3, 4]).aggregate((0, 0), seqOp, combOp)
+    assert res == (10, 4)
+
+    # TODO empty
+    # res = spark_session.sparkContext.parallelize([]).aggregate((0, 0), seqOp, combOp)
+    # assert res == (0, 0)


### PR DESCRIPTION
To avoid creating many instances of the same operation, similar to the RDD implementation, we pipeline every single `mapPartitions` call. 

