### PR TITLE
Adding support for `groupBy` / `groupByKey`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ that open a pull request and we will review it.
 
 | RDD                               | API                | Comment                                                           |
 |-----------------------------------|--------------------|-------------------------------------------------------------------|
-| aggregate                         | :x:                |                                                                   |
+| aggregate                         | :white_check_mark: |                                                                   |
 | aggregateByKey                    | :x:                |                                                                   |
 | barrier                           | :x:                |                                                                   |
 | cache                             | :x:                |                                                                   |
@@ -84,7 +84,7 @@ that open a pull request and we will review it.
 | countByKey                        | :x:                |                                                                   |
 | countByValue                      | :x:                |                                                                   |
 | distinct                          | :x:                |                                                                   |
-| filter                            | :x:                |                                                                   |
+| filter                            | :white_check_mark: |                                                                   |
 | first                             | :white_check_mark: |                                                                   |
 | flatMap                           | :x:                |                                                                   |
 | fold                              | :white_check_mark: | First version                                                     |
@@ -99,7 +99,7 @@ that open a pull request and we will review it.
 | groupBy                           | :x:                |                                                                   |
 | groupByKey                        | :x:                |                                                                   |
 | groupWith                         | :x:                |                                                                   |
-| histogram                         | :x:                |                                                                   |
+| histogram                         | :white_check_mark: |                                                                   |
 | id                                | :x:                |                                                                   |
 | intersection                      | :x:                |                                                                   |
 | isCheckpointed                    | :x:                |                                                                   |
@@ -116,10 +116,10 @@ that open a pull request and we will review it.
 | mapPartitionsWithIndex            | :x:                |                                                                   |
 | mapPartitionsWithSplit            | :x:                |                                                                   |
 | mapValues                         | :x:                |                                                                   |
-| max                               | :x:                |                                                                   |
-| mean                              | :x:                |                                                                   |
+| max                               | :white_check_mark: |                                                                   |
+| mean                              | :white_check_mark: |                                                                   |
 | meanApprox                        | :x:                |                                                                   |
-| min                               | :x:                |                                                                   |
+| min                               | :white_check_mark: |                                                                   |
 | name                              | :x:                |                                                                   |
 | partitionBy                       | :x:                |                                                                   |
 | persist                           | :x:                |                                                                   |
@@ -152,7 +152,7 @@ that open a pull request and we will review it.
 | take                              | :white_check_mark: | Ordering might not be guaranteed in the same way as it is in RDD. |
 | takeOrdered                       | :x:                |                                                                   |
 | takeSample                        | :x:                |                                                                   |
-| toDF                              | :x:                |                                                                   |
+| toDF                              | :white_check_mark: |                                                                   |
 | toDebugString                     | :x:                |                                                                   |
 | toLocalIterator                   | :x:                |                                                                   |
 | top                               | :x:                |                                                                   |

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ that open a pull request and we will review it.
 | getResourceProfile                | :x:                |                                                                   |
 | getStorageLevel                   | :x:                |                                                                   |
 | glom                              | :white_check_mark: |                                                                   |
-| groupBy                           | :x:                |                                                                   |
-| groupByKey                        | :x:                |                                                                   |
+| groupBy                           | :white_check_mark: |                                                                   |
+| groupByKey                        | :white_check_mark: |                                                                   |
 | groupWith                         | :x:                |                                                                   |
 | histogram                         | :white_check_mark: |                                                                   |
 | id                                | :x:                |                                                                   |
@@ -115,7 +115,7 @@ that open a pull request and we will review it.
 | mapPartitions                     | :white_check_mark: | First version, based on mapInArrow.                               |
 | mapPartitionsWithIndex            | :x:                |                                                                   |
 | mapPartitionsWithSplit            | :x:                |                                                                   |
-| mapValues                         | :x:                |                                                                   |
+| mapValues                         | :white_check_mark: |                                                                   |
 | max                               | :white_check_mark: |                                                                   |
 | mean                              | :white_check_mark: |                                                                   |
 | meanApprox                        | :x:                |                                                                   |
@@ -173,3 +173,10 @@ that open a pull request and we will review it.
 |-------------|--------------------|---------------------------------|
 | parallelize | :white_check_mark: | Does not support numSlices yet. |
 
+## Limitations
+
+* Error handling and checking is kind of limited right now. We try
+  to emulate the existing behavior, but this is not always possible
+  because the invariants are not encode in Python but rather somewhere
+  in Scala.
+* `numSlices` - we don't emulate this behavior for now.

--- a/congruity/rdd_adapter.py
+++ b/congruity/rdd_adapter.py
@@ -290,6 +290,24 @@ class RDDAdapter(Generic[T_co]):
     aggregate = RDD.aggregate
     aggregate.__doc__ = RDD.aggregate.__doc__
 
+    max = RDD.max
+    max.__doc__ = RDD.max.__doc__
+
+    min = RDD.min
+    min.__doc__ = RDD.min.__doc__
+
+    filter = RDD.filter
+    filter.__doc__ = RDD.filter.__doc__
+
+    histogram = RDD.histogram
+    histogram.__doc__ = RDD.histogram.__doc__
+
+    mean = RDD.mean
+    mean.__doc__ = RDD.mean.__doc__
+
+    variance = RDD.variance
+    variance.__doc__ = RDD.variance.__doc__
+
     class WrappedIterator(Iterable):
         """This is a helper class that wraps the iterator of RecordBatches as returned by
         mapInArrow and converts it into an iterator of the underlaying values."""

--- a/tests/test_rdd_adapter.py
+++ b/tests/test_rdd_adapter.py
@@ -246,3 +246,37 @@ def test_rdd_aggregate(spark_session: "SparkSession"):
     # TODO empty
     # res = spark_session.sparkContext.parallelize([]).aggregate((0, 0), seqOp, combOp)
     # assert res == (0, 0)
+
+
+def test_rdd_min(spark_session: "SparkSession"):
+    monkey_patch_spark()
+    df = spark_session.range(10).repartition(1)
+    assert df.rdd.map(lambda x: x[0]).min() == 0
+
+
+def test_rdd_max(spark_session: "SparkSession"):
+    monkey_patch_spark()
+    df = spark_session.range(10).repartition(1)
+    assert df.rdd.map(lambda x: x[0]).max() == 9
+
+
+def test_rdd_histogram(spark_session: "SparkSession"):
+    monkey_patch_spark()
+    rdd = spark_session.sparkContext.parallelize(range(10))
+    assert rdd.histogram(3) == ([0, 3, 6, 9], [3, 3, 4])
+
+
+def test_rdd_filter(spark_session: "SparkSession"):
+    monkey_patch_spark()
+    rdd = spark_session.sparkContext.parallelize(range(10))
+    assert rdd.filter(lambda x: x % 2 == 0).collect() == [0, 2, 4, 6, 8]
+
+def test_rdd_mean(spark_session: "SparkSession"):
+    monkey_patch_spark()
+    rdd = spark_session.sparkContext.parallelize(range(10))
+    assert rdd.mean() == 4.5
+
+def test_rdd_variance(spark_session: "SparkSession"):
+    monkey_patch_spark()
+    rdd = spark_session.sparkContext.parallelize(range(10))
+    assert rdd.variance() == 8.25

--- a/tests/test_rdd_adapter.py
+++ b/tests/test_rdd_adapter.py
@@ -271,10 +271,12 @@ def test_rdd_filter(spark_session: "SparkSession"):
     rdd = spark_session.sparkContext.parallelize(range(10))
     assert rdd.filter(lambda x: x % 2 == 0).collect() == [0, 2, 4, 6, 8]
 
+
 def test_rdd_mean(spark_session: "SparkSession"):
     monkey_patch_spark()
     rdd = spark_session.sparkContext.parallelize(range(10))
     assert rdd.mean() == 4.5
+
 
 def test_rdd_variance(spark_session: "SparkSession"):
     monkey_patch_spark()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adding support for `groupBy` and `groupByKey`. This patch adds a new RDD mapPartitions implementation that will create tuples and is then in turn used to run `groupBy` on the DataFrame efficiently.

On a high-level the execution flow is as follows:

```python
df.groupBy(bin_col1).applyInPandas(agg_all_values_for_a_key).mapInArrow(merge_k_v_to_tuple)
```

Once `applyInArrow` is available, we can switch the implementation to that.

### How was this patch tested?

Added new UT.