### PR TITLE
Added support for `collectAsMap` and `isEmpty` methods for rdd

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ that open a pull request and we will review it.
 | coalesce                          | :x:                |                                                                   |
 | cogroup                           | :x:                |                                                                   |
 | collect                           | :white_check_mark: |                                                                   |
-| collectAsMap                      | :x:                |                                                                   |
+| collectAsMap                      | :white_check_mark:                |                                                                   |
 | collectWithJobGroup               | :x:                |                                                                   |
 | combineByKey                      | :x:                |                                                                   |
 | count                             | :white_check_mark: |                                                                   |
@@ -103,7 +103,7 @@ that open a pull request and we will review it.
 | id                                | :x:                |                                                                   |
 | intersection                      | :x:                |                                                                   |
 | isCheckpointed                    | :x:                |                                                                   |
-| isEmpty                           | :x:                |                                                                   |
+| isEmpty                           | :white_check_mark:                |                                                                   |
 | isLocallyCheckpointed             | :x:                |                                                                   |
 | join                              | :x:                |                                                                   |
 | keyBy                             | :white_check_mark: |                                                                   |

--- a/congruity/rdd_adapter.py
+++ b/congruity/rdd_adapter.py
@@ -169,10 +169,10 @@ class RDDAdapter(Generic[T_co]):
         raise NotImplementedError(f"Collecting Data type {type(data)} is not supported")
 
     def toDF(
-            self,
-            schema: Optional[Union[sqltypes.AtomicType, sqltypes.StructType, str]] = None,
-            samplingRatio: Optional[float] = None,
-            verifySchema: bool = True,
+        self,
+        schema: Optional[Union[sqltypes.AtomicType, sqltypes.StructType, str]] = None,
+        samplingRatio: Optional[float] = None,
+        verifySchema: bool = True,
     ) -> "DataFrame":
         if isinstance(schema, sqltypes.StructType):
             verify_func = sqltypes._make_type_verifier(schema) if verifySchema else lambda _: True
@@ -236,10 +236,10 @@ class RDDAdapter(Generic[T_co]):
     toDF.__doc__ = RDD.toDF.__doc__
 
     def _infer_schema(
-            self,
-            rdd: "RDDAdapter",
-            samplingRatio: Optional[float] = None,
-            names: Optional[List[str]] = None,
+        self,
+        rdd: "RDDAdapter",
+        samplingRatio: Optional[float] = None,
+        names: Optional[List[str]] = None,
     ) -> sqltypes.StructType:
         first = rdd.first()
         if isinstance(first, Sized) and len(first) == 0:
@@ -272,7 +272,7 @@ class RDDAdapter(Generic[T_co]):
     take.__doc__ = RDD.take.__doc__
 
     def map(
-            self: "RDDApapter[T]", f: Callable[[T], U], preservesPartitioning=None
+        self: "RDDApapter[T]", f: Callable[[T], U], preservesPartitioning=None
     ) -> "RDDAdapter[U]":
         def func(iterator: Iterable[T]) -> Iterable[U]:
             return map(fail_on_stopiteration(f), iterator)
@@ -344,10 +344,10 @@ class RDDAdapter(Generic[T_co]):
     variance.__doc__ = RDD.variance.__doc__
 
     def groupBy(
-            self: "RDDAdapter[T]",
-            f: Callable[[T], K],
-            numPartitions: Optional[int] = None,
-            partitionFunc: Callable[[K], int] = lambda x: 1,
+        self: "RDDAdapter[T]",
+        f: Callable[[T], K],
+        numPartitions: Optional[int] = None,
+        partitionFunc: Callable[[K], int] = lambda x: 1,
     ) -> "RDDAdapter[Tuple[K, Iterable[T]]]":
         # First transform the date into a tuple, in contrast to the regular map calls, we're going to
         # create the tuple as something that has two columns rather than one serialized value.
@@ -363,13 +363,14 @@ class RDDAdapter(Generic[T_co]):
     groupBy.__doc__ = RDD.groupBy.__doc__
 
     def groupByKey(
-            self: "RDDAdapter[Tuple[K, V]]",
-            numPartitions: Optional[int] = None,
-            partitionFunc: Callable[[K], int] = lambda x: 1,
+        self: "RDDAdapter[Tuple[K, V]]",
+        numPartitions: Optional[int] = None,
+        partitionFunc: Callable[[K], int] = lambda x: 1,
     ) -> "RDDAdapter[Tuple[K, Iterable[V]]]":
 
         input_tuples = self
         if not isinstance(self, TupleAdapter):
+
             def extractor(x):
                 # Extracting the k, v using unpacking will automatically raise an exception if the
                 # number of values does not match.
@@ -409,7 +410,7 @@ class RDDAdapter(Generic[T_co]):
     mapValues.__doc__ = RDD.mapValues.__doc__
 
     def mapPartitions(
-            self, f: Callable[[Iterable[T]], Iterable[U]], preservesPartitioning=False
+        self, f: Callable[[Iterable[T]], Iterable[U]], preservesPartitioning=False
     ) -> "RDDAdapter[U]":
         # Every pipeline becomes mapPartitions in the end. So we pass the current RDD as the
         # previous reference and the next transformation function.

--- a/congruity/rdd_adapter.py
+++ b/congruity/rdd_adapter.py
@@ -28,7 +28,7 @@ from typing import (
     Callable,
     TypeVar,
     Hashable,
-    Generic,
+    Generic, Dict,
 )
 
 import pandas
@@ -46,7 +46,6 @@ V = TypeVar("V")
 V1 = TypeVar("V1")
 V2 = TypeVar("V2")
 V3 = TypeVar("V3")
-
 
 import pyarrow as pa
 from pyarrow import RecordBatch
@@ -151,6 +150,13 @@ class RDDAdapter(Generic[T_co]):
             return [self._unnest_data(row[0]) for row in data]
         return data
 
+    def collectAsMap(self: "RDDAdapter[Tuple[K, V]]") -> Dict[K, V]:
+        return dict(self.collect())
+
+    def isEmpty(self) -> bool:
+        return len(self.take(1)) == 0
+
+
     def _unnest_data(self, data: Any) -> Any:
         if any(map(lambda x: isinstance(data, x), (str, Row, int, float, bool, type(None)))):
             return data
@@ -160,10 +166,10 @@ class RDDAdapter(Generic[T_co]):
         raise NotImplementedError(f"Collecting Data type {type(data)} is not supported")
 
     def toDF(
-        self,
-        schema: Optional[Union[sqltypes.AtomicType, sqltypes.StructType, str]] = None,
-        samplingRatio: Optional[float] = None,
-        verifySchema: bool = True,
+            self,
+            schema: Optional[Union[sqltypes.AtomicType, sqltypes.StructType, str]] = None,
+            samplingRatio: Optional[float] = None,
+            verifySchema: bool = True,
     ) -> "DataFrame":
         if isinstance(schema, sqltypes.StructType):
             verify_func = sqltypes._make_type_verifier(schema) if verifySchema else lambda _: True
@@ -227,10 +233,10 @@ class RDDAdapter(Generic[T_co]):
     toDF.__doc__ = RDD.toDF.__doc__
 
     def _infer_schema(
-        self,
-        rdd: "RDDAdapter",
-        samplingRatio: Optional[float] = None,
-        names: Optional[List[str]] = None,
+            self,
+            rdd: "RDDAdapter",
+            samplingRatio: Optional[float] = None,
+            names: Optional[List[str]] = None,
     ) -> sqltypes.StructType:
         first = rdd.first()
         if isinstance(first, Sized) and len(first) == 0:
@@ -263,7 +269,7 @@ class RDDAdapter(Generic[T_co]):
     take.__doc__ = RDD.take.__doc__
 
     def map(
-        self: "RDDApapter[T]", f: Callable[[T], U], preservesPartitioning=None
+            self: "RDDApapter[T]", f: Callable[[T], U], preservesPartitioning=None
     ) -> "RDDAdapter[U]":
         def func(iterator: Iterable[T]) -> Iterable[U]:
             return map(fail_on_stopiteration(f), iterator)
@@ -335,10 +341,10 @@ class RDDAdapter(Generic[T_co]):
     variance.__doc__ = RDD.variance.__doc__
 
     def groupBy(
-        self: "RDDAdapter[T]",
-        f: Callable[[T], K],
-        numPartitions: Optional[int] = None,
-        partitionFunc: Callable[[K], int] = lambda x: 1,
+            self: "RDDAdapter[T]",
+            f: Callable[[T], K],
+            numPartitions: Optional[int] = None,
+            partitionFunc: Callable[[K], int] = lambda x: 1,
     ) -> "RDDAdapter[Tuple[K, Iterable[T]]]":
         # First transform the date into a tuple, in contrast to the regular map calls, we're going to
         # create the tuple as something that has two columns rather than one serialized value.
@@ -354,14 +360,13 @@ class RDDAdapter(Generic[T_co]):
     groupBy.__doc__ = RDD.groupBy.__doc__
 
     def groupByKey(
-        self: "RDDAdapter[Tuple[K, V]]",
-        numPartitions: Optional[int] = None,
-        partitionFunc: Callable[[K], int] = lambda x: 1,
+            self: "RDDAdapter[Tuple[K, V]]",
+            numPartitions: Optional[int] = None,
+            partitionFunc: Callable[[K], int] = lambda x: 1,
     ) -> "RDDAdapter[Tuple[K, Iterable[V]]]":
 
         input_tuples = self
         if not isinstance(self, TupleAdapter):
-
             def extractor(x):
                 # Extracting the k, v using unpacking will automatically raise an exception if the
                 # number of values does not match.
@@ -401,7 +406,7 @@ class RDDAdapter(Generic[T_co]):
     mapValues.__doc__ = RDD.mapValues.__doc__
 
     def mapPartitions(
-        self, f: Callable[[Iterable[T]], Iterable[U]], preservesPartitioning=False
+            self, f: Callable[[Iterable[T]], Iterable[U]], preservesPartitioning=False
     ) -> "RDDAdapter[U]":
         # Every pipeline becomes mapPartitions in the end. So we pass the current RDD as the
         # previous reference and the next transformation function.

--- a/congruity/rdd_adapter.py
+++ b/congruity/rdd_adapter.py
@@ -28,7 +28,8 @@ from typing import (
     Callable,
     TypeVar,
     Hashable,
-    Generic, Dict,
+    Generic,
+    Dict,
 )
 
 import pandas
@@ -156,7 +157,6 @@ class RDDAdapter(Generic[T_co]):
     def isEmpty(self) -> bool:
         return len(self.take(1)) == 0
 
-
     def _unnest_data(self, data: Any) -> Any:
         if any(map(lambda x: isinstance(data, x), (str, Row, int, float, bool, type(None)))):
             return data
@@ -166,10 +166,10 @@ class RDDAdapter(Generic[T_co]):
         raise NotImplementedError(f"Collecting Data type {type(data)} is not supported")
 
     def toDF(
-            self,
-            schema: Optional[Union[sqltypes.AtomicType, sqltypes.StructType, str]] = None,
-            samplingRatio: Optional[float] = None,
-            verifySchema: bool = True,
+        self,
+        schema: Optional[Union[sqltypes.AtomicType, sqltypes.StructType, str]] = None,
+        samplingRatio: Optional[float] = None,
+        verifySchema: bool = True,
     ) -> "DataFrame":
         if isinstance(schema, sqltypes.StructType):
             verify_func = sqltypes._make_type_verifier(schema) if verifySchema else lambda _: True
@@ -233,10 +233,10 @@ class RDDAdapter(Generic[T_co]):
     toDF.__doc__ = RDD.toDF.__doc__
 
     def _infer_schema(
-            self,
-            rdd: "RDDAdapter",
-            samplingRatio: Optional[float] = None,
-            names: Optional[List[str]] = None,
+        self,
+        rdd: "RDDAdapter",
+        samplingRatio: Optional[float] = None,
+        names: Optional[List[str]] = None,
     ) -> sqltypes.StructType:
         first = rdd.first()
         if isinstance(first, Sized) and len(first) == 0:
@@ -269,7 +269,7 @@ class RDDAdapter(Generic[T_co]):
     take.__doc__ = RDD.take.__doc__
 
     def map(
-            self: "RDDApapter[T]", f: Callable[[T], U], preservesPartitioning=None
+        self: "RDDApapter[T]", f: Callable[[T], U], preservesPartitioning=None
     ) -> "RDDAdapter[U]":
         def func(iterator: Iterable[T]) -> Iterable[U]:
             return map(fail_on_stopiteration(f), iterator)
@@ -341,10 +341,10 @@ class RDDAdapter(Generic[T_co]):
     variance.__doc__ = RDD.variance.__doc__
 
     def groupBy(
-            self: "RDDAdapter[T]",
-            f: Callable[[T], K],
-            numPartitions: Optional[int] = None,
-            partitionFunc: Callable[[K], int] = lambda x: 1,
+        self: "RDDAdapter[T]",
+        f: Callable[[T], K],
+        numPartitions: Optional[int] = None,
+        partitionFunc: Callable[[K], int] = lambda x: 1,
     ) -> "RDDAdapter[Tuple[K, Iterable[T]]]":
         # First transform the date into a tuple, in contrast to the regular map calls, we're going to
         # create the tuple as something that has two columns rather than one serialized value.
@@ -360,13 +360,14 @@ class RDDAdapter(Generic[T_co]):
     groupBy.__doc__ = RDD.groupBy.__doc__
 
     def groupByKey(
-            self: "RDDAdapter[Tuple[K, V]]",
-            numPartitions: Optional[int] = None,
-            partitionFunc: Callable[[K], int] = lambda x: 1,
+        self: "RDDAdapter[Tuple[K, V]]",
+        numPartitions: Optional[int] = None,
+        partitionFunc: Callable[[K], int] = lambda x: 1,
     ) -> "RDDAdapter[Tuple[K, Iterable[V]]]":
 
         input_tuples = self
         if not isinstance(self, TupleAdapter):
+
             def extractor(x):
                 # Extracting the k, v using unpacking will automatically raise an exception if the
                 # number of values does not match.
@@ -406,7 +407,7 @@ class RDDAdapter(Generic[T_co]):
     mapValues.__doc__ = RDD.mapValues.__doc__
 
     def mapPartitions(
-            self, f: Callable[[Iterable[T]], Iterable[U]], preservesPartitioning=False
+        self, f: Callable[[Iterable[T]], Iterable[U]], preservesPartitioning=False
     ) -> "RDDAdapter[U]":
         # Every pipeline becomes mapPartitions in the end. So we pass the current RDD as the
         # previous reference and the next transformation function.

--- a/tests/test_rdd_adapter.py
+++ b/tests/test_rdd_adapter.py
@@ -326,6 +326,11 @@ def test_collect_as_map(spark_session: "SparkSession"):
     res = rdd.collectAsMap()
     assert res == {1: 3, 2: 4}
 
+    # Negative scenario if the rdd type is not tuple
+    non_tuple_rdd = spark_session.sparkContext.parallelize([1, 2, 3, 4])
+    with pytest.raises(TypeError):
+        non_tuple_rdd.collectAsMap()
+
 
 def test_rdd_is_empty(spark_session: "SparkSession"):
     monkey_patch_spark()

--- a/tests/test_rdd_adapter.py
+++ b/tests/test_rdd_adapter.py
@@ -317,3 +317,27 @@ def test_rdd_mapValues(spark_session: "SparkSession"):
     rdd = spark_session.sparkContext.parallelize([(1, 2), (1, 3), (2, 4)])
     res = rdd.mapValues(lambda x: x * 2).collect()
     assert res == [(1, 4), (1, 6), (2, 8)]
+
+
+def test_collect_as_map(spark_session: "SparkSession"):
+    monkey_patch_spark()
+    rdd = spark_session.sparkContext.parallelize([(1, 2), (1, 3), (2, 4)])
+    assert rdd.isEmpty() is False
+    res = rdd.collectAsMap()
+    assert res == {1: 3, 2: 4}
+
+
+def test_rdd_is_empty(spark_session: "SparkSession"):
+    monkey_patch_spark()
+    schema = StructType([])
+    #Unable to use emptyRDD and send empty list to parallelize hence this approach
+    empty_df = spark_session.createDataFrame([], schema)
+    empty_rdd = empty_df.rdd
+    non_empty_rdd = spark_session.sparkContext.parallelize([1, 2, 3])
+
+    assert empty_rdd.isEmpty() is True
+    assert non_empty_rdd.isEmpty() is False
+    assert empty_rdd.count() == 0
+    assert non_empty_rdd.count() > 0
+    assert empty_rdd.collect() == []
+    assert non_empty_rdd.collect() == [1, 2, 3]

--- a/tests/test_rdd_adapter.py
+++ b/tests/test_rdd_adapter.py
@@ -330,7 +330,7 @@ def test_collect_as_map(spark_session: "SparkSession"):
 def test_rdd_is_empty(spark_session: "SparkSession"):
     monkey_patch_spark()
     schema = StructType([])
-    #Unable to use emptyRDD and send empty list to parallelize hence this approach
+    # Unable to use emptyRDD and send empty list to parallelize hence this approach
     empty_df = spark_session.createDataFrame([], schema)
     empty_rdd = empty_df.rdd
     non_empty_rdd = spark_session.sparkContext.parallelize([1, 2, 3])


### PR DESCRIPTION
Added support for following RDD methods
1. collectAsMap
2. IsEmpty 

This PR also contains tests to validate the above implemented methods.